### PR TITLE
Bundle Exec Jekyll Serve in Jekyll Devcontainer

### DIFF
--- a/jeykll/devcontainer.json
+++ b/jeykll/devcontainer.json
@@ -23,7 +23,7 @@
     "updateContentCommand": "cd website && gem update --system && bundle install",
     "postCreateCommand": "echo \"alias nb='$(pwd)/.devcontainer/new_branch.sh'\" >> ~/.bashrc",
     "postAttachCommand": {
-        "server": "cd website && jekyll serve"
+        "server": "cd website && bundle exec jekyll serve"
     },
     "portsAttributes": {
         "4000": {


### PR DESCRIPTION
> This command, on the other hand, serves your site while ensuring that all the Ruby gems specified in your project's Gemfile are being used. bundle exec is a Bundler command that runs an executable in the context of your bundle, effectively prefixing your command with bundle exec to ensure that it uses the gem versions defined in your Gemfile.lock